### PR TITLE
Add support for alternative HTTPS ports

### DIFF
--- a/network/https-redirect/Dockerfile
+++ b/network/https-redirect/Dockerfile
@@ -8,6 +8,9 @@ MAINTAINER      Eugene Cheah <eugene@picoded.com>
 #
 ENV HTTPCODE 307
 
+# HTTPS port to redirect to, by default 443
+ENV TARGET_PORT 443
+
 # Port to expose, this is currently fixed to 80
 EXPOSE 80
 
@@ -22,10 +25,15 @@ RUN echo '#!/bin/sh'                                                            
 	echo '# Goes into the nginx config folder'                                          >> /entrypoint/primer.sh && \
 	echo 'cd /etc/nginx/conf.d/'                                                        >> /entrypoint/primer.sh && \
 	echo ''                                                                             >> /entrypoint/primer.sh && \
+	echo 'TARGET_PORT_URL=""'                                                           >> /entrypoint/primer.sh && \
+	echo 'if [ $TARGET_PORT -ne 443 ]; then'                                            >> /entrypoint/primer.sh && \
+	echo '    TARGET_PORT_URL=":$TARGET_PORT"'                                          >> /entrypoint/primer.sh && \
+	echo 'fi'                                                                           >> /entrypoint/primer.sh && \
+	echo ''                                                                             >> /entrypoint/primer.sh && \
 	echo '# Setup the server config'                                                    >> /entrypoint/primer.sh && \
 	echo 'echo "server {"                                          > default.conf'      >> /entrypoint/primer.sh && \
 	echo 'echo "   listen 80;"                                     >> default.conf'     >> /entrypoint/primer.sh && \
-	echo 'echo "   return $HTTPCODE https://\$host\$request_uri;"  >> default.conf'     >> /entrypoint/primer.sh && \
+	echo 'echo "   return $HTTPCODE https://\$host${TARGET_PORT_URL}\$request_uri;"  >> default.conf'     >> /entrypoint/primer.sh && \
 	echo 'echo "}"                                                 >> default.conf'     >> /entrypoint/primer.sh && \
 	echo ''                                                                             >> /entrypoint/primer.sh && \
 	echo '# Goes back to root folder'                                                   >> /entrypoint/primer.sh && \

--- a/network/https-redirect/README.md
+++ b/network/https-redirect/README.md
@@ -7,7 +7,7 @@ https://github.com/picoded/dockerfiles/tree/master/network/https-redirect
 A simple nginx server, which redirects all its requests from HTTP to HTTPS. 
 Useful in enforcing a HTTPS connection =)
 
-It only has a single optional configuration, the HTTP Code to reply with, as documented below.
+It has two optional configurations, the HTTP Code to reply with, and the port to redirect to, as documented below.
 
 ``` 
 #
@@ -16,6 +16,9 @@ It only has a single optional configuration, the HTTP Code to reply with, as doc
 # Or 308 - Permanent Redirect
 #
 ENV HTTPCODE 307
+
+# HTTPS port to redirect to, by default 443
+ENV TARGET_PORT 443
 ```
 
 # Issue filling


### PR DESCRIPTION
This allows a user to change the port used for redirection (by default 443).